### PR TITLE
Add relative file path to resolved migration

### DIFF
--- a/Sources/Crane/Resolution/ResolvedMigration.swift
+++ b/Sources/Crane/Resolution/ResolvedMigration.swift
@@ -13,6 +13,7 @@
 
 package struct ResolvedMigration: Identifiable {
     package let id: MigrationID
+    package let relativeFilePath: String?
     private let _sqlScript: @Sendable () async throws -> String
 
     package var sqlScript: String {
@@ -21,8 +22,9 @@ package struct ResolvedMigration: Identifiable {
         }
     }
 
-    package init(id: MigrationID, sqlScript: @escaping @Sendable () async throws -> String) {
+    package init(id: MigrationID, relativeFilePath: String?, sqlScript: @escaping @Sendable () async throws -> String) {
         self.id = id
+        self.relativeFilePath = relativeFilePath
         self._sqlScript = sqlScript
     }
 }

--- a/Tests/CraneTests/Resolution/ResolvedMigrationTests.swift
+++ b/Tests/CraneTests/Resolution/ResolvedMigrationTests.swift
@@ -24,6 +24,7 @@ struct `Resolved Migration` {
 
             let migration = ResolvedMigration(
                 id: .apply(version: 1, description: "create_users"),
+                relativeFilePath: "migrations/v1.create_users.apply.sql",
                 sqlScript: { sqlScript }
             )
 
@@ -35,6 +36,7 @@ struct `Resolved Migration` {
 
             let migration = ResolvedMigration(
                 id: .apply(version: 1, description: "create_users"),
+                relativeFilePath: "migrations/v1.create_users.apply.sql",
                 sqlScript: { throw TestError() }
             )
 


### PR DESCRIPTION
This PR adds the relative file path to `ResolvedMigration` in preparation for the upcoming schema history tracking. The file path is optional in case we want to add support for non-file-system-based migration resolvers down the line.