### PR TITLE
Match repeatable migrations by description instead of file path

### DIFF
--- a/Sources/Crane/History/SchemaHistoryRow.swift
+++ b/Sources/Crane/History/SchemaHistoryRow.swift
@@ -25,8 +25,8 @@ public struct SchemaHistoryRow: Hashable, Sendable {
     /// Version number for versioned migrations, nil for repeatable migrations.
     public let version: Int?
 
-    /// Description of the migration. For file-system resolvers, this contains the relative file path.
-    /// Other resolvers may use this field to store resolver-specific identifying information.
+    /// Human-readable description of the migration, parsed from the migration's identifier
+    /// (e.g. "create_users").
     public let description: String
 
     /// Type of migration.
@@ -52,7 +52,7 @@ public struct SchemaHistoryRow: Hashable, Sendable {
     /// - Parameters:
     ///   - rank: Order in which this migration was applied.
     ///   - version: Version number for versioned migrations, nil for repeatable migrations.
-    ///   - description: Description of the migration. For file-system resolvers, this contains the relative file path.
+    ///   - description: Human-readable description parsed from the migration identifier.
     ///   - type: Type of migration operation.
     ///   - checksum: Checksum for detecting changes to the migration script.
     ///   - user: Database user who executed the migration.
@@ -84,7 +84,6 @@ public struct SchemaHistoryRow: Hashable, Sendable {
     package init(
         id: MigrationID,
         rank: Int,
-        description: String,
         checksum: String,
         user: String,
         executionDate: Date,
@@ -103,7 +102,7 @@ public struct SchemaHistoryRow: Hashable, Sendable {
             self.type = .repeatable
         }
         self.rank = rank
-        self.description = description
+        self.description = id.description
         self.checksum = checksum
         self.user = user
         self.executionDate = executionDate

--- a/Sources/Crane/MigrationID.swift
+++ b/Sources/Crane/MigrationID.swift
@@ -16,6 +16,13 @@ package enum MigrationID: Hashable, Comparable {
     case undo(version: Int, description: String)
     case repeatable(description: String)
 
+    package var description: String {
+        switch self {
+        case .apply(_, let description), .undo(_, let description), .repeatable(let description):
+            description
+        }
+    }
+
     package static func < (lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case let (.apply(lhsVersion, _), .apply(rhsVersion, _)):

--- a/Sources/Crane/Migrator.swift
+++ b/Sources/Crane/Migrator.swift
@@ -62,7 +62,6 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
                     let sqlScript = try await migration.sqlScript
                     try await executeMigration(
                         id: migration.id,
-                        description: migration.description,
                         sqlScript: sqlScript,
                         rank: nextRank,
                         user: user
@@ -71,11 +70,11 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
                 }
             case .undo:
                 continue
-            case .repeatable:
+            case .repeatable(let description):
                 let sqlScript = try await migration.sqlScript
                 let scriptChecksum = checksum(sqlScript: sqlScript)
                 let shouldExecute: Bool
-                if let lastChecksum = state.lastRepeatableChecksums[migration.description] {
+                if let lastChecksum = state.lastRepeatableChecksums[description] {
                     shouldExecute = scriptChecksum != lastChecksum
                 } else {
                     shouldExecute = true
@@ -83,7 +82,6 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
                 if shouldExecute {
                     try await executeMigration(
                         id: migration.id,
-                        description: migration.description,
                         sqlScript: sqlScript,
                         rank: nextRank,
                         user: user
@@ -96,7 +94,6 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
 
     private func executeMigration(
         id: MigrationID,
-        description: String,
         sqlScript: String,
         rank: Int,
         user: String
@@ -109,7 +106,6 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
             let row = SchemaHistoryRow(
                 id: id,
                 rank: rank,
-                description: description,
                 checksum: scriptChecksum,
                 user: user,
                 executionDate: now(),
@@ -123,7 +119,7 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
     /// Errors that can occur during migration validation.
     package enum ValidationError: Error, Equatable {
         /// A migration file has been modified after being applied to the database.
-        case checksumMismatch(id: MigrationID, description: String, expected: String, actual: String)
+        case checksumMismatch(id: MigrationID, script: String, expected: String, actual: String)
 
         /// A previously executed migration is no longer resolved by the migration resolver.
         case missingMigration(version: Int, type: SchemaHistoryRow.MigrationType, description: String)
@@ -176,7 +172,7 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
                 if currentChecksum != row.checksum {
                     throw ValidationError.checksumMismatch(
                         id: resolvedMigration.id,
-                        description: row.description,
+                        script: resolvedMigration.script,
                         expected: row.checksum,
                         actual: currentChecksum
                     )
@@ -187,7 +183,8 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
             case .repeatable:
                 if let version = row.version {
                     throw ValidationError.repeatableMigrationWithVersion(
-                        version: version, description: row.description
+                        version: version,
+                        description: row.description
                     )
                 }
 

--- a/Sources/Crane/Resolution/FileSystem/FileSystemMigrationResolver.swift
+++ b/Sources/Crane/Resolution/FileSystem/FileSystemMigrationResolver.swift
@@ -49,8 +49,8 @@ package struct FileSystemMigrationResolver: MigrationResolver {
                     return nil
                 }
                 let id = try MigrationID(parsingFileName: url.lastPathComponent)
-                let description = String(path.dropFirst(rootPathPrefixLength))
-                return ResolvedMigration(id: id, description: description) {
+                let script = String(path.dropFirst(rootPathPrefixLength))
+                return ResolvedMigration(id: id, script: script) {
                     try String(contentsOf: url, encoding: .utf8)
                 }
             }

--- a/Sources/Crane/Resolution/ResolvedMigration.swift
+++ b/Sources/Crane/Resolution/ResolvedMigration.swift
@@ -14,17 +14,17 @@
 /// A migration that has been resolved by a ``MigrationResolver``.
 ///
 /// This type represents a migration that has been discovered and can be executed.
-/// It contains the migration's identity, a description, and provides access to the SQL script.
+/// It contains the migration's identity, a pointer to its source, and provides access to the SQL script.
 package struct ResolvedMigration: Identifiable {
     /// The unique identifier for this migration.
     package let id: MigrationID
 
-    /// A description of the migration source.
+    /// A pointer to the migration source.
     ///
     /// The content of this field depends on the resolver that created the migration:
     /// - For file-system resolvers: Contains the relative file path (e.g., "migrations/v1.create_users.apply.sql")
     /// - For other resolvers: May contain resolver-specific identifying information
-    package let description: String
+    package let script: String
 
     private let _sqlScript: @Sendable () async throws -> String
 
@@ -41,11 +41,11 @@ package struct ResolvedMigration: Identifiable {
     ///
     /// - Parameters:
     ///   - id: The unique identifier for the migration.
-    ///   - description: A description of the migration source. For file-system resolvers, this should be the relative file path.
+    ///   - script: A pointer to the migration source. For file-system resolvers, this should be the relative file path.
     ///   - sqlScript: A closure that provides the SQL script content when called. This allows for lazy loading of the script.
-    package init(id: MigrationID, description: String, sqlScript: @escaping @Sendable () async throws -> String) {
+    package init(id: MigrationID, script: String, sqlScript: @escaping @Sendable () async throws -> String) {
         self.id = id
-        self.description = description
+        self.script = script
         self._sqlScript = sqlScript
     }
 }

--- a/Tests/CraneTests/History/SchemaHistoryRowTests.swift
+++ b/Tests/CraneTests/History/SchemaHistoryRowTests.swift
@@ -24,7 +24,7 @@ import Testing
         let expectedRow = SchemaHistoryRow(
             rank: 1,
             version: 42,
-            description: "migrations/v42.create_users.apply.sql",
+            description: "create_users",
             type: .apply,
             checksum: checksum,
             user: "slashmo",
@@ -36,7 +36,6 @@ import Testing
         let row = SchemaHistoryRow(
             id: id,
             rank: 1,
-            description: "migrations/v42.create_users.apply.sql",
             checksum: checksum,
             user: "slashmo",
             executionDate: executionDate,
@@ -55,7 +54,7 @@ import Testing
         let expectedRow = SchemaHistoryRow(
             rank: 2,
             version: 42,
-            description: "migrations/v42.create_users.undo.sql",
+            description: "create_users",
             type: .undo,
             checksum: checksum,
             user: "slashmo",
@@ -67,7 +66,6 @@ import Testing
         let row = SchemaHistoryRow(
             id: id,
             rank: 2,
-            description: "migrations/v42.create_users.undo.sql",
             checksum: checksum,
             user: "slashmo",
             executionDate: executionDate,
@@ -88,7 +86,7 @@ import Testing
         let expectedRow = SchemaHistoryRow(
             rank: 3,
             version: nil,
-            description: "migrations/repeat.refresh_views.sql",
+            description: "refresh_views",
             type: .repeatable,
             checksum: checksum,
             user: "slashmo",
@@ -100,7 +98,6 @@ import Testing
         let row = SchemaHistoryRow(
             id: id,
             rank: 3,
-            description: "migrations/repeat.refresh_views.sql",
             checksum: checksum,
             user: "slashmo",
             executionDate: executionDate,

--- a/Tests/CraneTests/MigratorTests.swift
+++ b/Tests/CraneTests/MigratorTests.swift
@@ -93,7 +93,7 @@ import Foundation
 
             let expectedError = Crane.Migrator<MockTarget>.ValidationError.checksumMismatch(
                 id: .apply(version: 1, description: "create_users"),
-                description: "migrations/v1.create_users.apply.sql",
+                script: "migrations/v1.create_users.apply.sql",
                 expected: originalChecksum,
                 actual: checksum(sqlScript: modifiedScript)
             )
@@ -118,7 +118,7 @@ import Foundation
 
             let expectedError = Crane.Migrator<MockTarget>.ValidationError.checksumMismatch(
                 id: .undo(version: 1, description: "create_users"),
-                description: "migrations/v1.create_users.undo.sql",
+                script: "migrations/v1.create_users.undo.sql",
                 expected: originalChecksum,
                 actual: checksum(sqlScript: modifiedScript)
             )
@@ -151,6 +151,23 @@ import Foundation
                 ]
             )
             let target = MockTarget(history: [SchemaHistoryRow.Repeatable.refreshViews()])
+
+            let migrator = Crane.Migrator(resolver: resolver, target: target)
+
+            try await migrator.apply()
+
+            #expect(await target.executedSQLScripts.isEmpty)
+        }
+
+        @Test func `Skips moved repeatable migration when checksum unchanged`() async throws {
+            let resolver = MockResolver(
+                migrations: [
+                    ResolvedMigration.Repeatable.refreshViews(path: "migrations/repeatable/repeat.refresh_views.sql")
+                ]
+            )
+            let target = MockTarget(
+                history: [SchemaHistoryRow.Repeatable.refreshViews()]
+            )
 
             let migrator = Crane.Migrator(resolver: resolver, target: target)
 
@@ -355,7 +372,7 @@ import Foundation
             let expectedError = Crane.Migrator<MockTarget>.ValidationError.missingMigration(
                 version: 1,
                 type: .apply,
-                description: "migrations/v1.create_users.apply.sql"
+                description: "create_users"
             )
             await #expect(throws: expectedError) {
                 try await migrator.apply()
@@ -371,7 +388,7 @@ import Foundation
             let expectedError = Crane.Migrator<MockTarget>.ValidationError.missingMigration(
                 version: 1,
                 type: .undo,
-                description: "migrations/v1.create_users.undo.sql"
+                description: "create_users"
             )
             await #expect(throws: expectedError) {
                 try await migrator.apply()
@@ -389,7 +406,7 @@ import Foundation
                     SchemaHistoryRow(
                         rank: 1,
                         version: 42,
-                        description: "migrations/repeat.refresh_views.sql",
+                        description: "refresh_views",
                         type: .repeatable,
                         checksum: checksum(sqlScript: "SELECT VERSION();"),
                         user: "mock_user",
@@ -404,7 +421,7 @@ import Foundation
 
             let expectedError = Crane.Migrator<MockTarget>.ValidationError.repeatableMigrationWithVersion(
                 version: 42,
-                description: "migrations/repeat.refresh_views.sql"
+                description: "refresh_views"
             )
             await #expect(throws: expectedError) {
                 try await migrator.apply()
@@ -422,7 +439,7 @@ import Foundation
                     SchemaHistoryRow(
                         rank: 1,
                         version: nil,
-                        description: "migrations/v1.create_users.apply.sql",
+                        description: "create_users",
                         type: .apply,
                         checksum: checksum(sqlScript: SQLScriptStub.createUsersTable),
                         user: "mock_user",
@@ -437,7 +454,7 @@ import Foundation
 
             let expectedError = Crane.Migrator<MockTarget>.ValidationError.missingVersion(
                 type: .apply,
-                description: "migrations/v1.create_users.apply.sql"
+                description: "create_users"
             )
             await #expect(throws: expectedError) {
                 try await migrator.apply()
@@ -455,7 +472,7 @@ import Foundation
                     SchemaHistoryRow(
                         rank: 1,
                         version: nil,
-                        description: "migrations/v1.create_users.undo.sql",
+                        description: "create_users",
                         type: .undo,
                         checksum: checksum(sqlScript: SQLScriptStub.dropUsersTable),
                         user: "mock_user",
@@ -470,7 +487,7 @@ import Foundation
 
             let expectedError = Crane.Migrator<MockTarget>.ValidationError.missingVersion(
                 type: .undo,
-                description: "migrations/v1.create_users.undo.sql"
+                description: "create_users"
             )
             await #expect(throws: expectedError) {
                 try await migrator.apply()
@@ -531,7 +548,6 @@ extension SchemaHistoryRow {
     fileprivate init(
         id: MigrationID,
         rank: Int = 1,
-        description: String,
         checksum: String,
         user: String = "mock_user",
         executionDate: Date = .stub,
@@ -554,7 +570,7 @@ extension SchemaHistoryRow {
         self.init(
             rank: rank,
             version: version,
-            description: description,
+            description: id.description,
             type: type,
             checksum: checksum,
             user: user,
@@ -577,21 +593,23 @@ private enum SQLScriptStub {
 extension ResolvedMigration {
     fileprivate enum Apply {
         static func createUsersTable(
-            script: String = SQLScriptStub.createUsersTable
+            script: String = SQLScriptStub.createUsersTable,
+            path: String = "migrations/v1.create_users.apply.sql"
         ) -> ResolvedMigration {
             ResolvedMigration(
                 id: .apply(version: 1, description: "create_users"),
-                description: "migrations/v1.create_users.apply.sql",
+                script: path,
                 sqlScript: { script }
             )
         }
 
         static func addEmailToUsersTable(
-            script: String = SQLScriptStub.addEmailToUsersTable
+            script: String = SQLScriptStub.addEmailToUsersTable,
+            path: String = "migrations/v2.add_email.apply.sql"
         ) -> ResolvedMigration {
             ResolvedMigration(
                 id: .apply(version: 2, description: "add_email"),
-                description: "migrations/v2.add_email.apply.sql",
+                script: path,
                 sqlScript: { script }
             )
         }
@@ -599,11 +617,12 @@ extension ResolvedMigration {
 
     fileprivate enum Undo {
         static func dropUsersTable(
-            script: String = SQLScriptStub.dropUsersTable
+            script: String = SQLScriptStub.dropUsersTable,
+            path: String = "migrations/v1.create_users.undo.sql"
         ) -> ResolvedMigration {
             ResolvedMigration(
                 id: .undo(version: 1, description: "create_users"),
-                description: "migrations/v1.create_users.undo.sql",
+                script: path,
                 sqlScript: { script }
             )
         }
@@ -611,11 +630,12 @@ extension ResolvedMigration {
 
     fileprivate enum Repeatable {
         static func refreshViews(
-            script: String = SQLScriptStub.createOrReplaceActiveUsersView
+            script: String = SQLScriptStub.createOrReplaceActiveUsersView,
+            path: String = "migrations/repeat.refresh_views.sql"
         ) -> ResolvedMigration {
             ResolvedMigration(
                 id: .repeatable(description: "refresh_views"),
-                description: "migrations/repeat.refresh_views.sql",
+                script: path,
                 sqlScript: { script }
             )
         }
@@ -633,7 +653,6 @@ extension SchemaHistoryRow {
             SchemaHistoryRow(
                 id: .apply(version: 1, description: "create_users"),
                 rank: rank,
-                description: "migrations/v1.create_users.apply.sql",
                 checksum: Crane.checksum(sqlScript: SQLScriptStub.createUsersTable),
                 user: user,
                 executionDate: executionDate,
@@ -650,7 +669,6 @@ extension SchemaHistoryRow {
             SchemaHistoryRow(
                 id: .apply(version: 2, description: "add_email"),
                 rank: rank,
-                description: "migrations/v2.add_email.apply.sql",
                 checksum: Crane.checksum(sqlScript: SQLScriptStub.addEmailToUsersTable),
                 user: user,
                 executionDate: executionDate,
@@ -669,7 +687,6 @@ extension SchemaHistoryRow {
             SchemaHistoryRow(
                 id: .undo(version: 1, description: "create_users"),
                 rank: rank,
-                description: "migrations/v1.create_users.undo.sql",
                 checksum: Crane.checksum(sqlScript: SQLScriptStub.dropUsersTable),
                 user: user,
                 executionDate: executionDate,
@@ -688,7 +705,6 @@ extension SchemaHistoryRow {
             SchemaHistoryRow(
                 id: .repeatable(description: "refresh_views"),
                 rank: rank,
-                description: "migrations/repeat.refresh_views.sql",
                 checksum: Crane.checksum(sqlScript: SQLScriptStub.createOrReplaceActiveUsersView),
                 user: user,
                 executionDate: executionDate,

--- a/Tests/CraneTests/Resolution/FileSystem/FileSystemMigrationResolverTests.swift
+++ b/Tests/CraneTests/Resolution/FileSystem/FileSystemMigrationResolverTests.swift
@@ -53,17 +53,17 @@ struct `File-System Migration Resolver` {
                 try await migrations.equatable == [
                     EquatableResolvedMigration(
                         id: .apply(version: 1, description: "create_users"),
-                        description: "migrations/v1.create_users.apply.sql",
+                        script: "migrations/v1.create_users.apply.sql",
                         sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
                     ),
                     EquatableResolvedMigration(
                         id: .undo(version: 1, description: "create_users"),
-                        description: "migrations/v1.create_users.undo.sql",
+                        script: "migrations/v1.create_users.undo.sql",
                         sqlScript: "DROP TABLE users;"
                     ),
                     EquatableResolvedMigration(
                         id: .repeatable(description: "version"),
-                        description: "migrations/repeat.version.sql",
+                        script: "migrations/repeat.version.sql",
                         sqlScript: "SELECT VERSION();"
                     ),
                 ]
@@ -99,12 +99,12 @@ struct `File-System Migration Resolver` {
                 try await migrations.equatable == [
                     EquatableResolvedMigration(
                         id: .apply(version: 1, description: "create_users"),
-                        description: "migrations/v1.create_users.apply.sql",
+                        script: "migrations/v1.create_users.apply.sql",
                         sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
                     ),
                     EquatableResolvedMigration(
                         id: .undo(version: 1, description: "create_users"),
-                        description: "migrations/v1.create_users.undo.sql",
+                        script: "migrations/v1.create_users.undo.sql",
                         sqlScript: "DROP TABLE users;"
                     ),
                 ]
@@ -141,17 +141,17 @@ struct `File-System Migration Resolver` {
                 try await migrations.equatable == [
                     EquatableResolvedMigration(
                         id: .apply(version: 1, description: "create_users"),
-                        description: "migrations/v1.create_users.apply.sql",
+                        script: "migrations/v1.create_users.apply.sql",
                         sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
                     ),
                     EquatableResolvedMigration(
                         id: .undo(version: 1, description: "create_users"),
-                        description: "migrations/v1.create_users.undo.sql",
+                        script: "migrations/v1.create_users.undo.sql",
                         sqlScript: "DROP TABLE users;"
                     ),
                     EquatableResolvedMigration(
                         id: .repeatable(description: "version"),
-                        description: "migrations/repeatable/repeat.version.sql",
+                        script: "migrations/repeatable/repeat.version.sql",
                         sqlScript: "SELECT VERSION();"
                     ),
                 ]
@@ -190,7 +190,7 @@ struct `File-System Migration Resolver` {
                     try await migrations.equatable == [
                         EquatableResolvedMigration(
                             id: .apply(version: 1, description: "create_users"),
-                            description: "sql/v1.create_users.apply.sql",
+                            script: "sql/v1.create_users.apply.sql",
                             sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
                         )
                     ]
@@ -220,7 +220,7 @@ struct `File-System Migration Resolver` {
                     try await migrations.equatable == [
                         EquatableResolvedMigration(
                             id: .apply(version: 1, description: "create_users"),
-                            description: "migrations/v1.create_users.apply.sql",
+                            script: "migrations/v1.create_users.apply.sql",
                             sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
                         )
                     ]
@@ -245,18 +245,18 @@ extension [ResolvedMigration] {
 
 private struct EquatableResolvedMigration: Equatable {
     let id: MigrationID
-    let description: String
+    let script: String
     let sqlScript: String
 
-    init(id: MigrationID, description: String, sqlScript: String) {
+    init(id: MigrationID, script: String, sqlScript: String) {
         self.id = id
-        self.description = description
+        self.script = script
         self.sqlScript = sqlScript
     }
 
     init(_ resolvedMigration: ResolvedMigration) async throws {
         self.id = resolvedMigration.id
-        self.description = resolvedMigration.description
+        self.script = resolvedMigration.script
         self.sqlScript = try await resolvedMigration.sqlScript
     }
 }

--- a/Tests/CraneTests/Resolution/ResolvedMigrationTests.swift
+++ b/Tests/CraneTests/Resolution/ResolvedMigrationTests.swift
@@ -24,7 +24,7 @@ struct `Resolved Migration` {
 
             let migration = ResolvedMigration(
                 id: .apply(version: 1, description: "create_users"),
-                description: "migrations/v1.create_users.apply.sql",
+                script: "migrations/v1.create_users.apply.sql",
                 sqlScript: { sqlScript }
             )
 
@@ -36,7 +36,7 @@ struct `Resolved Migration` {
 
             let migration = ResolvedMigration(
                 id: .apply(version: 1, description: "create_users"),
-                description: "migrations/v1.create_users.apply.sql",
+                script: "migrations/v1.create_users.apply.sql",
                 sqlScript: { throw TestError() }
             )
 


### PR DESCRIPTION
Repeatable migrations were re-executing when their file moved into a subdirectory, because `Migrator` keyed the checksum lookup on the resolver-supplied path rather than the migration's identity.

This PR splits the parsed migration name from the file path on `ResolvedMigration` and keys repeatable matching on the parsed name, bringing it in line with how versioned migrations are already matched. `ValidationError` is updated accordingly: the history-derived cases carry the parsed description, and checksumMismatch carries script for diagnostics.