### PR TITLE
Resolve migrations recursively from each configured path

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     project:
       default:
         threshold: 5%
+    patch:
+      default:
+        target: 95%

--- a/Benchmarks/CraneBenchmarks/FileSystemMigrationResolverBenchmarks.swift
+++ b/Benchmarks/CraneBenchmarks/FileSystemMigrationResolverBenchmarks.swift
@@ -17,6 +17,7 @@ import Foundation
 
 func fileSystemMigrationResolverBenchmarks() {
     makeFileSystemMigrationResolverResolveBenchmark()
+    makeFileSystemMigrationResolverResolveRecursivelyBenchmark()
     makeFileSystemMigrationResolverReadSQLScriptBenchmark()
 }
 
@@ -25,10 +26,7 @@ private func makeFileSystemMigrationResolverResolveBenchmark() -> Benchmark? {
     let baseURL = URL.temporaryDirectory.appending(path: UUID().uuidString)
     let migrationsURL = baseURL.appending(path: "migrations")
 
-    return Benchmark(
-        "FileSystemMigrationResolver: Resolve",
-        configuration: .init(scalingFactor: .kilo)
-    ) { benchmark in
+    return Benchmark("FileSystemMigrationResolver: Resolve") { benchmark in
         for _ in benchmark.scaledIterations {
             let resolver = try FileSystemMigrationResolver(
                 paths: ["migrations"],
@@ -43,6 +41,39 @@ private func makeFileSystemMigrationResolverResolveBenchmark() -> Benchmark? {
         for i in 0..<1000 {
             let url = migrationsURL.appending(path: "v\(i).example.apply.sql")
             try stubMigrationData.write(to: url)
+        }
+    } teardown: {
+        try FileManager.default.removeItem(at: baseURL)
+    }
+}
+
+@discardableResult
+private func makeFileSystemMigrationResolverResolveRecursivelyBenchmark() -> Benchmark? {
+    let baseURL = URL.temporaryDirectory.appending(path: UUID().uuidString)
+    let migrationsURL = baseURL.appending(path: "migrations")
+
+    return Benchmark("FileSystemMigrationResolver: Resolve recursively") { benchmark in
+        for _ in benchmark.scaledIterations {
+            let resolver = try FileSystemMigrationResolver(
+                paths: ["migrations"],
+                rootPath: baseURL.path
+            )
+            blackHole(try await resolver.migrations())
+        }
+    } setup: {
+        try FileManager.default.createDirectory(at: migrationsURL, withIntermediateDirectories: true)
+
+        // 1000 files split across 10 nested subdirectories (100 each).
+        let stubMigrationData = Data("SELECT VERSION();\n".utf8)
+        var version = 0
+        for subdirIndex in 0..<10 {
+            let subdirURL = migrationsURL.appending(path: "subdir\(subdirIndex)")
+            try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: false)
+            for _ in 0..<100 {
+                let url = subdirURL.appending(path: "v\(version).example.apply.sql")
+                try stubMigrationData.write(to: url)
+                version += 1
+            }
         }
     } teardown: {
         try FileManager.default.removeItem(at: baseURL)

--- a/Sources/Crane/Resolution/FileSystem/FileSystemMigrationResolver.swift
+++ b/Sources/Crane/Resolution/FileSystem/FileSystemMigrationResolver.swift
@@ -20,6 +20,7 @@ import Foundation
 package struct FileSystemMigrationResolver: MigrationResolver {
     private let rootURL: URL
     private let urls: [URL]
+    private let pathStrings: [String]
 
     package init(
         paths: [String],
@@ -31,37 +32,74 @@ package struct FileSystemMigrationResolver: MigrationResolver {
         guard !paths.isEmpty else {
             throw FileSystemMigrationResolverError.noPaths
         }
+        self.pathStrings = paths
         self.urls = paths.map { rootURL.appendingPathComponent($0) }
     }
 
     package func migrations() async throws -> [ResolvedMigration] {
-        let fileURLs = try urls.flatMap { url in
-            try FileManager.default.contentsOfDirectory(atPath: url.path).map { url.appendingPathComponent($0) }
+        var seen = [MigrationID: String]()
+        var migrations = [ResolvedMigration]()
+
+        for (pathString, url) in zip(pathStrings, urls) {
+            // Apple Foundation's `enumerator(atPath:)` returns nil for missing/non-directory paths, but
+            // swift-corelibs-foundation returns a non-nil enumerator that yields nothing — so we need an
+            // explicit existence check for portable error reporting.
+            var isDirectory = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory else {
+                throw FileSystemMigrationResolverError.unreadablePath(url.path)
+            }
+
+            guard let enumerator = FileManager.default.enumerator(atPath: url.path) else {
+                throw FileSystemMigrationResolverError.unreadablePath(url.path)
+            }
+
+            while let relativePath = enumerator.nextObject() as? String {
+                // `fileAttributes` reads from the stat the enumerator already performed.
+                let isDirectory = enumerator.fileAttributes?[.type] as? FileAttributeType == .typeDirectory
+
+                // Skip hidden files and directories. For hidden directories, also short-circuit descent —
+                // important on Kubernetes ConfigMap mounts where a hidden timestamped sibling directory
+                // holds the actual files (without the skip we'd walk every file in the sibling tree only
+                // to discard them, and the duplicate-ID check below would trip on each one).
+                //
+                // See also: https://github.com/flyway/flyway/issues/1807
+                if relativePath.hasPrefix(".") || relativePath.contains("/.") {
+                    if isDirectory {
+                        enumerator.skipDescendants()
+                    }
+                    continue
+                }
+
+                // The enumerator yields directories alongside files; we only want files.
+                if isDirectory { continue }
+
+                let fileURL = url.appendingPathComponent(relativePath)
+                guard fileURL.pathExtension == "sql" else { continue }
+
+                let id = try MigrationID(parsingFileName: fileURL.lastPathComponent)
+                let script = "\(pathString)/\(relativePath)"
+
+                if let existing = seen[id] {
+                    throw FileSystemMigrationResolverError.duplicateMigrationID(id, scripts: [existing, script])
+                }
+                seen[id] = script
+
+                migrations.append(
+                    ResolvedMigration(id: id, script: script) {
+                        try String(contentsOf: fileURL, encoding: .utf8)
+                    }
+                )
+            }
         }
 
-        let rootPathPrefixLength = (rootURL.path + "/").count
-
-        let migrations = try fileURLs.lazy
-            .compactMap { url -> ResolvedMigration? in
-                var isDirectory = false
-                let path = url.path
-                guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory), !isDirectory else {
-                    return nil
-                }
-                let id = try MigrationID(parsingFileName: url.lastPathComponent)
-                let script = String(path.dropFirst(rootPathPrefixLength))
-                return ResolvedMigration(id: id, script: script) {
-                    try String(contentsOf: url, encoding: .utf8)
-                }
-            }
-            .sorted(by: { $0.id < $1.id })
-
-        return migrations
+        return migrations.sorted(by: { $0.id < $1.id })
     }
 }
 
-enum FileSystemMigrationResolverError: Error {
+enum FileSystemMigrationResolverError: Error, Equatable {
     case noPaths
+    case unreadablePath(String)
+    case duplicateMigrationID(MigrationID, scripts: [String])
 }
 
 #if canImport(ObjectiveC)

--- a/Tests/CraneTests/Resolution/FileSystem/FileSystemMigrationResolverTests.swift
+++ b/Tests/CraneTests/Resolution/FileSystem/FileSystemMigrationResolverTests.swift
@@ -71,15 +71,8 @@ struct `File-System Migration Resolver` {
         }
     }
 
-    @Test func `Ignores migration files from nested paths if not configured`() async throws {
-        try await withTemporaryDirectories("migrations") { rootURL, urls in
-            let nestedFolderURL = rootURL.appendingPathComponent("migrations/repeatable")
-            try FileManager.default.createDirectory(at: nestedFolderURL, withIntermediateDirectories: false)
-            try "SELECT VERSION();".write(
-                to: nestedFolderURL.appendingPathComponent("repeat.version.sql"),
-                atomically: true,
-                encoding: .utf8
-            )
+    @Test func `Resolves migration files recursively from nested directories`() async throws {
+        try await withTemporaryDirectories("migrations", "migrations/nested") { rootURL, urls in
             try "CREATE TABLE users (id UUID PRIMARY KEY);".write(
                 to: urls[0].appendingPathComponent("v1.create_users.apply.sql"),
                 atomically: true,
@@ -87,6 +80,11 @@ struct `File-System Migration Resolver` {
             )
             try "DROP TABLE users;".write(
                 to: urls[0].appendingPathComponent("v1.create_users.undo.sql"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try "SELECT VERSION();".write(
+                to: urls[1].appendingPathComponent("repeat.version.sql"),
                 atomically: true,
                 encoding: .utf8
             )
@@ -107,20 +105,20 @@ struct `File-System Migration Resolver` {
                         script: "migrations/v1.create_users.undo.sql",
                         sqlScript: "DROP TABLE users;"
                     ),
+                    EquatableResolvedMigration(
+                        id: .repeatable(description: "version"),
+                        script: "migrations/nested/repeat.version.sql",
+                        sqlScript: "SELECT VERSION();"
+                    ),
                 ]
             )
         }
     }
 
-    @Test func `Resolves migration files from nested paths if configured`() async throws {
-        try await withTemporaryDirectories("migrations", "migrations/repeatable") { rootURL, urls in
+    @Test func `Composes migrations from multiple independent roots`() async throws {
+        try await withTemporaryDirectories("a", "b") { rootURL, urls in
             try "CREATE TABLE users (id UUID PRIMARY KEY);".write(
                 to: urls[0].appendingPathComponent("v1.create_users.apply.sql"),
-                atomically: true,
-                encoding: .utf8
-            )
-            try "DROP TABLE users;".write(
-                to: urls[0].appendingPathComponent("v1.create_users.undo.sql"),
                 atomically: true,
                 encoding: .utf8
             )
@@ -130,10 +128,7 @@ struct `File-System Migration Resolver` {
                 encoding: .utf8
             )
 
-            let resolver = try FileSystemMigrationResolver(
-                paths: ["migrations", "migrations/repeatable"],
-                rootPath: rootURL.path
-            )
+            let resolver = try FileSystemMigrationResolver(paths: ["a", "b"], rootPath: rootURL.path)
 
             let migrations = try await resolver.migrations()
 
@@ -141,17 +136,12 @@ struct `File-System Migration Resolver` {
                 try await migrations.equatable == [
                     EquatableResolvedMigration(
                         id: .apply(version: 1, description: "create_users"),
-                        script: "migrations/v1.create_users.apply.sql",
+                        script: "a/v1.create_users.apply.sql",
                         sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
                     ),
                     EquatableResolvedMigration(
-                        id: .undo(version: 1, description: "create_users"),
-                        script: "migrations/v1.create_users.undo.sql",
-                        sqlScript: "DROP TABLE users;"
-                    ),
-                    EquatableResolvedMigration(
                         id: .repeatable(description: "version"),
-                        script: "migrations/repeatable/repeat.version.sql",
+                        script: "b/repeat.version.sql",
                         sqlScript: "SELECT VERSION();"
                     ),
                 ]
@@ -162,6 +152,111 @@ struct `File-System Migration Resolver` {
     @Test func `Fails to initialize without paths`() async throws {
         #expect(throws: (any Error).self) {
             try FileSystemMigrationResolver(paths: [])
+        }
+    }
+
+    @Test func `Throws when a configured path does not exist`() async throws {
+        try await withTemporaryDirectories("a") { rootURL, _ in
+            let resolver = try FileSystemMigrationResolver(paths: ["b"], rootPath: rootURL.path)
+            let expectedPath = rootURL.appendingPathComponent("b").path
+
+            await #expect(throws: FileSystemMigrationResolverError.unreadablePath(expectedPath)) {
+                _ = try await resolver.migrations()
+            }
+        }
+    }
+
+    @Test func `Skips hidden directories`() async throws {
+        // Without this, Foundation's enumerator descends into the hidden timestamped sibling Kubernetes
+        // maintains for ConfigMap mounts, surfacing each SQL file twice.
+        try await withTemporaryDirectories("migrations", "migrations/..hidden") { rootURL, urls in
+            try "CREATE TABLE users (id UUID PRIMARY KEY);".write(
+                to: urls[0].appendingPathComponent("v1.create_users.apply.sql"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try "SELECT VERSION();".write(
+                to: urls[1].appendingPathComponent("repeat.version.sql"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let resolver = try FileSystemMigrationResolver(paths: ["migrations"], rootPath: rootURL.path)
+
+            let migrations = try await resolver.migrations()
+
+            #expect(
+                try await migrations.equatable == [
+                    EquatableResolvedMigration(
+                        id: .apply(version: 1, description: "create_users"),
+                        script: "migrations/v1.create_users.apply.sql",
+                        sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
+                    )
+                ]
+            )
+        }
+    }
+
+    @Test func `Skips non-SQL files`() async throws {
+        try await withTemporaryDirectories("migrations") { rootURL, urls in
+            try "CREATE TABLE users (id UUID PRIMARY KEY);".write(
+                to: urls[0].appendingPathComponent("v1.create_users.apply.sql"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try "# Migrations".write(
+                to: urls[0].appendingPathComponent("README.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try "binary".write(
+                to: urls[0].appendingPathComponent(".DS_Store"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let resolver = try FileSystemMigrationResolver(paths: ["migrations"], rootPath: rootURL.path)
+
+            let migrations = try await resolver.migrations()
+
+            #expect(
+                try await migrations.equatable == [
+                    EquatableResolvedMigration(
+                        id: .apply(version: 1, description: "create_users"),
+                        script: "migrations/v1.create_users.apply.sql",
+                        sqlScript: "CREATE TABLE users (id UUID PRIMARY KEY);"
+                    )
+                ]
+            )
+        }
+    }
+
+    @Test func `Throws when the same migration ID is resolved from multiple paths`() async throws {
+        try await withTemporaryDirectories("a", "b") { rootURL, urls in
+            try "CREATE TABLE users (id UUID PRIMARY KEY);".write(
+                to: urls[0].appendingPathComponent("v1.create_users.apply.sql"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try "CREATE TABLE users (id UUID PRIMARY KEY);".write(
+                to: urls[1].appendingPathComponent("v1.create_users.apply.sql"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let resolver = try FileSystemMigrationResolver(paths: ["a", "b"], rootPath: rootURL.path)
+
+            await #expect(
+                throws: FileSystemMigrationResolverError.duplicateMigrationID(
+                    .apply(version: 1, description: "create_users"),
+                    scripts: [
+                        "a/v1.create_users.apply.sql",
+                        "b/v1.create_users.apply.sql",
+                    ]
+                )
+            ) {
+                _ = try await resolver.migrations()
+            }
         }
     }
 


### PR DESCRIPTION
`FileSystemMigrationResolver` now walks each entry in paths recursively and filters to `.sql` files, so nested layouts like `migrations/repeatable/` work without listing every subfolder in `paths`.

Hidden directories are skipped — without that, Foundation's enumerator descends into the timestamped sibling directories Kubernetes maintains alongside ConfigMap volume mounts, surfacing every SQL file twice and tripping duplicate-ID detection (see Flyway #1807).

Two new typed errors fail loud on configuration mistakes: `pathDoesNotExist` when a configured path is missing, and `duplicateMigrationID` when the same id is resolved from overlapping paths — so paths: ["migrations", "migrations/nested"] is now a configuration error rather than producing silent duplicates.