### PR TITLE
Remove crane scoping from ConfigReader init

### DIFF
--- a/Sources/Crane/Migrator+ConfigReader.swift
+++ b/Sources/Crane/Migrator+ConfigReader.swift
@@ -15,10 +15,11 @@
 public import Configuration
 
 extension Migrator {
+    /// Creates a new migrator from a configuration reader.
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, *)
     public init(reader: ConfigReader, target: Target) throws {
         try self.init(
-            resolver: FileSystemMigrationResolver(reader: reader.scoped(to: "crane")),
+            resolver: FileSystemMigrationResolver(reader: reader),
             target: target
         )
     }

--- a/Tests/CraneTests/MigratorTests.swift
+++ b/Tests/CraneTests/MigratorTests.swift
@@ -511,8 +511,8 @@ import Foundation
 
                 let reader = ConfigReader(
                     provider: InMemoryProvider(values: [
-                        "crane.rootPath": ConfigValue(.string(rootURL.path), isSecret: false),
-                        "crane.paths": ConfigValue(.stringArray(["sql"]), isSecret: false),
+                        "rootPath": ConfigValue(.string(rootURL.path), isSecret: false),
+                        "paths": ConfigValue(.stringArray(["sql"]), isSecret: false),
                     ])
                 )
                 let target = MockTarget()


### PR DESCRIPTION
Removes hard-coded `crane` scoping from `ConfigReader` initializer, following the best practices outlined in the Swift Configuration docs: https://swiftpackageindex.com/apple/swift-configuration/1.2.0/documentation/configuration/best-practices#Use-scoped-configuration