### PR TITLE
Make current database user optional

### DIFF
--- a/Sources/Crane/History/SchemaHistoryRow.swift
+++ b/Sources/Crane/History/SchemaHistoryRow.swift
@@ -36,7 +36,9 @@ public struct SchemaHistoryRow: Hashable, Sendable {
     public let checksum: String
 
     /// Database user who executed the migration.
-    public let user: String
+    ///
+    /// Set to `nil` in case the migration target doesn't have the concept of users (e.g. SQLite).
+    public let user: String?
 
     /// Timestamp when the migration was applied.
     public let executionDate: Date
@@ -56,6 +58,7 @@ public struct SchemaHistoryRow: Hashable, Sendable {
     ///   - type: Type of migration operation.
     ///   - checksum: Checksum for detecting changes to the migration script.
     ///   - user: Database user who executed the migration.
+    ///     Set this to `nil` in case your migration target doesn't have the concept of users (e.g. SQLite).
     ///   - executionDate: Timestamp when the migration was applied.
     ///   - duration: Execution duration of the migration.
     ///   - succeeded: Whether the migration executed successfully.
@@ -65,7 +68,7 @@ public struct SchemaHistoryRow: Hashable, Sendable {
         description: String,
         type: MigrationType,
         checksum: String,
-        user: String,
+        user: String?,
         executionDate: Date,
         duration: Duration,
         succeeded: Bool
@@ -85,7 +88,7 @@ public struct SchemaHistoryRow: Hashable, Sendable {
         id: MigrationID,
         rank: Int,
         checksum: String,
-        user: String,
+        user: String?,
         executionDate: Date,
         duration: Duration,
         succeeded: Bool

--- a/Sources/Crane/Migrator.swift
+++ b/Sources/Crane/Migrator.swift
@@ -109,7 +109,7 @@ public struct Migrator<Target: MigrationTarget>: Sendable {
         id: MigrationID,
         sqlScript: String,
         rank: Int,
-        user: String
+        user: String?
     ) async throws {
         let scriptChecksum = checksum(sqlScript: sqlScript)
         try await target.withTransaction {

--- a/Sources/Crane/Target/MigrationTarget.swift
+++ b/Sources/Crane/Target/MigrationTarget.swift
@@ -21,7 +21,10 @@ public protocol MigrationTarget: Sendable {
     /// Retrieve the username of the current database connection.
     ///
     /// Used to populate the `user` field of ``SchemaHistoryRow`` when recording migrations.
-    func currentUser() async throws -> String
+    ///
+    /// - Note: Return `nil` in case your target doesn't have the concept of users (e.g. SQLite).
+    ///   Don't return `nil` on failures, throw instead.
+    func currentUser() async throws -> String?
 
     /// Retrieve the complete migration history from the target system.
     ///

--- a/Tests/CraneTests/MigratorTests.swift
+++ b/Tests/CraneTests/MigratorTests.swift
@@ -250,6 +250,32 @@ import Foundation
                 )
             }
 
+            @Test func `Records nil user when target returns no current user`() async throws {
+                let resolver = MockResolver(
+                    migrations: [
+                        ResolvedMigration.Apply.createUsersTable()
+                    ]
+                )
+                let target = MockTarget(currentUser: nil)
+
+                let migrator = Crane.Migrator(
+                    resolver: resolver,
+                    target: target,
+                    measure: {
+                        try await $0()
+                        return .milliseconds(42)
+                    },
+                    now: { .stub }
+                )
+                try await migrator.apply()
+
+                #expect(
+                    await target.recordedRows == [
+                        SchemaHistoryRow.Apply.createUsersTable(user: nil)
+                    ]
+                )
+            }
+
             @Test func `Records executed repeatable migration`() async throws {
                 let resolver = MockResolver(
                     migrations: [
@@ -549,7 +575,7 @@ extension SchemaHistoryRow {
         id: MigrationID,
         rank: Int = 1,
         checksum: String,
-        user: String = "mock_user",
+        user: String? = "mock_user",
         executionDate: Date = .stub,
         duration: Duration = .milliseconds(42),
         succeeded: Bool = true
@@ -646,7 +672,7 @@ extension SchemaHistoryRow {
     fileprivate enum Apply {
         static func createUsersTable(
             rank: Int = 1,
-            user: String = "mock_user",
+            user: String? = "mock_user",
             executionDate: Date = .stub,
             duration: Duration = .milliseconds(42)
         ) -> SchemaHistoryRow {

--- a/Tests/CraneTests/MockTarget.swift
+++ b/Tests/CraneTests/MockTarget.swift
@@ -19,16 +19,18 @@ actor MockTarget: MigrationTarget {
     private(set) var transactionCount = 0
     private(set) var setUpHistoryCallCount = 0
     private let historyResult: Result<[SchemaHistoryRow], any Error>
+    private let stubbedCurrentUser: String?
 
-    init(history: [SchemaHistoryRow] = []) {
+    init(history: [SchemaHistoryRow] = [], currentUser: String? = "mock_user") {
         self.historyResult = .success(history)
+        self.stubbedCurrentUser = currentUser
     }
 
     func setUpHistory() async throws {
         setUpHistoryCallCount += 1
     }
 
-    func currentUser() async throws -> String { "mock_user" }
+    func currentUser() async throws -> String? { stubbedCurrentUser }
 
     func history() async throws -> [SchemaHistoryRow] {
         try historyResult.get()


### PR DESCRIPTION
`SchemaHistoryRow.user` was non-nullable, which forced every target to produce a string regardless of whether the underlying database actually has a notion of users. SQLite, for example, has none — so an adapter would have to invent a sentinel like `""`, conflating "no user concept" with "user concept exists but unknown".